### PR TITLE
Build universal (Python 2 and 3 compat.) wheels by default.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
xref https://packaging.python.org/tutorials/distributing-packages/#universal-wheels

Ideally you'd publish these wheels along with your source files to PyPI when you do releases (just publish the results of "python setup.py bdist_wheel" in addition to sdist).