### PR TITLE
Lift strict pin on bagit==1.6.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
                       'tzlocal',
                       'requests>=2.7.0',
                       'certifi',
-                      'bagit==1.6.4'],
+                      'bagit>=1.6.4'],
     license='Apache 2.0',
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
As bagit==1.6.4 can't be installed (by pip) on python 3:
```
root@e5e36d3697a2:/# pip install bdbag
Collecting bdbag
  Downloading https://files.pythonhosted.org/packages/53/c1/c28ec526b699813287f94cd4b9971918881505ecb1e7760a3a0fa8d9bf9c/bdbag-1.4.1-py2.py3-none-any.whl (63kB)
    100% |################################| 71kB 838kB/s
Collecting certifi (from bdbag)
  Using cached https://files.pythonhosted.org/packages/7c/e6/92ad559b7192d846975fc916b65f667c7b8c3a32bea7372340bfe9a15fa5/certifi-2018.4.16-py2.py3-none-any.whl
Collecting bagit==1.6.4 (from bdbag)
  Using cached https://files.pythonhosted.org/packages/64/91/4363e2d56a81431ef7b86cd8f0a530a5729032f207eb3b756eb29b4ed282/bagit-1.6.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-k6o0335t/bagit/setup.py", line 19, in <module>
        long_description = readme.read()
      File "/galaxy_venv3/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1111: ordinal not in range(128)

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-k6o0335t/bagit/
```

This has been fixed on 1.7.0.