### PR TITLE
Add missing import. Fixes #31

### DIFF
--- a/bdbag/fetch/transports/fetch_globus.py
+++ b/bdbag/fetch/transports/fetch_globus.py
@@ -18,6 +18,7 @@ import importlib
 import logging
 import platform
 from bdbag import urlsplit, get_typed_exception
+from bdbag.fetch import ensure_valid_output_path
 import bdbag.fetch.auth.keychain as keychain
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fetch transport for globus was missing an import.
```
fetch_globus.py:76:23: F821 undefined name 'ensure_valid_output_path'
```