### PR TITLE
Fixes directory paths with slash at the end during "archive_bag".

### DIFF
--- a/bdbag/bdbag_api.py
+++ b/bdbag/bdbag_api.py
@@ -316,6 +316,9 @@ def archive_bag(bag_path, bag_archiver):
         logger.error("Error while archiving bag: %s", e)
         raise e
 
+    if bag_path[-1] == os.sep:
+        bag_path = bag_path[:-1]
+
     logger.info("Archiving bag (%s): %s" % (bag_archiver, bag_path))
     tarmode = None
     archive = None

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -478,6 +478,14 @@ class TestAPI(BaseTest):
             self.assertTrue(ospif(archive_file))
         except Exception as e:
             self.fail(get_typed_exception(e))
+    
+    def test_archive_bag_tar_with_trailing_slash(self):
+        logger.info(self.getTestHeader('archive bag tar format'))
+        try:
+            archive_file = bdb.archive_bag(self.test_bag_dir + os.sep, 'tar')
+            self.assertTrue(ospif(archive_file))
+        except Exception as e:
+            self.fail(get_typed_exception(e))
 
     def test_archive_bag_incomplete_structure(self):
         logger.info(self.getTestHeader('archive incomplete bag zip format'))


### PR DESCRIPTION
If the user passes something like "/Users/me/some_directory/" then what happens is that the tar ends up as "/Users/me/some_directory/.tar" instead of ""/Users/me/some_directory.tar" like it should be. This PR is just two lines that remove the trailing os.sep character from the bag_path so that the tar ends up where it should be.