### PR TITLE
Fixes auth config validation for Globus fetch

### DIFF
--- a/bdbag/fetch/transports/fetch_globus.py
+++ b/bdbag/fetch/transports/fetch_globus.py
@@ -38,9 +38,9 @@ class GlobusTransferFetchTransport(BaseFetchTransport):
             return False
         if not kc.has_auth_attr(auth, "auth_params"):
             return False
-        if not kc.has_auth_attr(auth.auth_params, "transfer_token"):
+        if not kc.has_auth_attr(auth["auth_params"], "transfer_token"):
             return False
-        if not kc.has_auth_attr(auth.auth_params, "local_endpoint"):
+        if not kc.has_auth_attr(auth["auth_params"], "local_endpoint"):
             return False
 
         return True


### PR DESCRIPTION
Fetching via globus gives the following error in 1.6.3 because `validate_auth_config()` is not expecting `auth` to be an `OrderedDict`. This PR hopefully fixes that.

For example:
```
$ pip3 freeze | grep bdbag
bdbag==1.6.3

$ cat fetch.txt
globus://82f1b5c6-6e9b-11e5-ba47-22000b92c6ec//published/publication_113/data/metadata.json 
    4475 data/data/data/metadata.json

$ bdbag --resolve-fetch all .

2022-02-11 13:13:02,557 - INFO - Attempting to resolve remote file references from fetch.txt.
2022-02-11 13:13:02,599 - ERROR - Globus Transfer request exception: [AttributeError] 'collections.OrderedDict' 
    object has no attribute 'auth_params'
2022-02-11 13:13:02,599 - INFO - Fetch complete. Elapsed time: 0:00:00.041566
```